### PR TITLE
fix: Mcp servers object mapping

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1205,8 +1205,8 @@ app.get('/api/mcp', (req, res) => {
         }
 
         const aggregated = loadAggregatedConfig();
-        if (aggregated.mcpServers) {
-            for (const [name, config] of Object.entries(aggregated.mcpServers)) {
+        if (aggregated.mcp) {
+            for (const [name, config] of Object.entries(aggregated.mcp)) {
                 if (!mcpMap.has(name)) {
                     mcpMap.set(name, {
                         name,


### PR DESCRIPTION
## Summary

Fixes the MCP servers mapping in the `/api/mcp` endpoint.

The aggregated config uses the `mcp` property, but the endpoint was checking `mcpServers`, so MCP servers defined in the JSON config were not being included in the response.

## Changes

- Replaced `aggregated.mcpServers` with `aggregated.mcp`.
- Iterates over the correct MCP config object when building the MCP map.

## Testing

- Verified locally that MCP servers from the aggregated config are now included in `/api/mcp`.