### PR TITLE
fix(opencode): expose config and rules resolution context

### DIFF
--- a/client-next/src/app/settings/code/page.tsx
+++ b/client-next/src/app/settings/code/page.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useApp } from "@/lib/context";
-import { getSystemTools } from "@/lib/api";
-import type { SystemToolInfo } from "@/types";
+import { getApiBaseUrl, getPaths, getProjectRules, getSystemTools } from "@/lib/api";
+import type { PathsInfo, RulesResponse, SystemToolInfo } from "@/types";
 import { PageHelp } from "@/components/page-help";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -44,19 +44,30 @@ export default function CodeSettingsPage() {
   const { config, saveConfig } = useApp();
   const [tools, setTools] = useState<SystemToolInfo[]>([]);
   const [loading, setLoading] = useState(true);
+  const [backendUrl, setBackendUrl] = useState<string | null>(null);
+  const [paths, setPaths] = useState<PathsInfo | null>(null);
+  const [rules, setRules] = useState<RulesResponse | null>(null);
 
   useEffect(() => {
-    const loadTools = async () => {
+    const loadDetails = async () => {
       try {
-        const data = await getSystemTools();
-        setTools(data);
+        const [apiBaseUrl, pathsData, rulesData, toolsData] = await Promise.all([
+          getApiBaseUrl(),
+          getPaths(),
+          getProjectRules(),
+          getSystemTools(),
+        ]);
+        setBackendUrl(apiBaseUrl);
+        setPaths(pathsData);
+        setRules(rulesData);
+        setTools(toolsData);
       } catch (err: any) {
-        toast.error(err?.message || "Failed to load system tools");
+        toast.error(err?.message || "Failed to load code settings metadata");
       } finally {
         setLoading(false);
       }
     };
-    loadTools();
+    loadDetails();
   }, []);
 
   const toolMap = useMemo(() => {
@@ -93,7 +104,46 @@ export default function CodeSettingsPage() {
 
       <Card>
         <CardHeader>
+          <CardTitle>Resolution Context</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            This shows the live backend URL, the active OpenCode config path, and the rules file the backend resolved.
+          </p>
+        </CardHeader>
+        <CardContent className="grid gap-3 text-sm md:grid-cols-2">
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Backend URL</div>
+            <div className="font-mono break-all">{loading ? "Loading..." : backendUrl || "Unknown"}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Active Config</div>
+            <div className="font-mono break-all">{loading ? "Loading..." : paths?.current || "Unknown"}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Detected Config</div>
+            <div className="font-mono break-all">{loading ? "Loading..." : paths?.detected || "None"}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Project Rules</div>
+            <div className="font-mono break-all">{loading ? "Loading..." : rules?.path || "None"}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Rules Source</div>
+            <div className="font-mono break-all">{loading ? "Loading..." : rules?.source || "none"}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">PATH Strategy</div>
+            <div className="font-mono break-all">Backend shell lookup (`which` on WSL/Linux, `where` on Windows)</div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
           <CardTitle>LSP Servers</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Detection uses the backend shell PATH. If a binary lives in `~/.nvm`, `~/.local/bin`, `~/.cargo/bin`, or
+            similar, start OpenCode Studio from a shell that exports that PATH.
+          </p>
         </CardHeader>
         <CardContent className="space-y-4">
           {LSP_LIST.map((item) => {
@@ -105,9 +155,18 @@ export default function CodeSettingsPage() {
                   <div className="font-medium">{item.label}</div>
                   <div className="text-xs text-muted-foreground">{item.id}</div>
                 </div>
-                <Badge variant={tool?.available ? "secondary" : "outline"}>
-                  {loading ? "Checking" : tool?.available ? "Detected" : "Not Found"}
-                </Badge>
+                <div className="space-y-1">
+                  <Badge variant={tool?.available ? "secondary" : "outline"}>
+                    {loading ? "Checking" : tool?.available ? "Detected in PATH" : "Not Found in PATH"}
+                  </Badge>
+                  <div className="text-[11px] text-muted-foreground break-all">
+                    {loading
+                      ? "Looking up via backend `which`"
+                      : tool?.available
+                        ? tool.path
+                        : `Searched via backend \`which ${item.tool}\``}
+                  </div>
+                </div>
                 <div className="flex items-center gap-2">
                   <Switch
                     checked={!cfg?.disabled}
@@ -129,7 +188,7 @@ export default function CodeSettingsPage() {
       <Card>
         <CardHeader>
           <PageHelp title="Code Settings" docUrl="https://opencode.ai/docs" docTitle="LSP & Formatter Manager" />
-          <CardTitle>LSP Servers</CardTitle>
+          <CardTitle>Formatters</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           {FORMATTER_LIST.map((item) => {
@@ -141,9 +200,18 @@ export default function CodeSettingsPage() {
                   <div className="font-medium">{item.label}</div>
                   <div className="text-xs text-muted-foreground">{item.id}</div>
                 </div>
-                <Badge variant={tool?.available ? "secondary" : "outline"}>
-                  {loading ? "Checking" : tool?.available ? "Detected" : "Not Found"}
-                </Badge>
+                <div className="space-y-1">
+                  <Badge variant={tool?.available ? "secondary" : "outline"}>
+                    {loading ? "Checking" : tool?.available ? "Detected in PATH" : "Not Found in PATH"}
+                  </Badge>
+                  <div className="text-[11px] text-muted-foreground break-all">
+                    {loading
+                      ? "Looking up via backend `which`"
+                      : tool?.available
+                        ? tool.path
+                        : `Searched via backend \`which ${item.tool}\``}
+                  </div>
+                </div>
                 <div className="flex items-center gap-2">
                   <Switch
                     checked={!cfg?.disabled}

--- a/client-next/src/lib/api.ts
+++ b/client-next/src/lib/api.ts
@@ -5,48 +5,80 @@ const BACKEND_BASE_PORT = 1920;
 const MAX_PORT_TRIES = 10;
 
 let cachedApiUrl: string | null = null;
+let resolvingApiUrl: Promise<string> | null = null;
+
+async function probeBackendUrl(url: string): Promise<string | null> {
+    try {
+        await axios.get(`${url}/health`, { timeout: 500 });
+        return url;
+    } catch {
+        return null;
+    }
+}
 
 async function discoverBackendPort(): Promise<string> {
     if (cachedApiUrl) return cachedApiUrl;
+    if (resolvingApiUrl) return resolvingApiUrl;
 
-    for (let i = 0; i < MAX_PORT_TRIES; i++) {
-        const port = BACKEND_BASE_PORT + i;
-        const testUrl = `http://127.0.0.1:${port}/api`;
+    resolvingApiUrl = (async () => {
+        const preferred = [envApiUrl, DEFAULT_API_URL].filter(Boolean) as string[];
+        for (const candidate of preferred) {
+            const ok = await probeBackendUrl(candidate);
+            if (ok) {
+                cachedApiUrl = ok;
+                return ok;
+            }
+        }
 
-        try {
-            const response = await axios.get(`${testUrl}/health`, { timeout: 500 });
-            cachedApiUrl = testUrl;
-            return testUrl;
-        } catch {}
+        for (let i = 0; i < MAX_PORT_TRIES; i++) {
+            const port = BACKEND_BASE_PORT + i;
+            const testUrl = `http://127.0.0.1:${port}/api`;
+            const ok = await probeBackendUrl(testUrl);
+            if (ok) {
+                cachedApiUrl = ok;
+                return ok;
+            }
+        }
+
+        throw new Error(`Cannot find backend server on ports ${BACKEND_BASE_PORT}-${BACKEND_BASE_PORT + MAX_PORT_TRIES - 1}`);
+    })();
+
+    try {
+        return await resolvingApiUrl;
+    } finally {
+        resolvingApiUrl = null;
     }
-
-    throw new Error(`Cannot find backend server on ports ${BACKEND_BASE_PORT}-${BACKEND_BASE_PORT + MAX_PORT_TRIES - 1}`);
 }
 
 const envApiUrl = process.env.NEXT_PUBLIC_API_URL;
 
 const CLIENT_VERSION = process.env.NEXT_PUBLIC_APP_VERSION || '1.17.0';
 
+const DEFAULT_API_URL = 'http://127.0.0.1:1920/api';
+
 const api = axios.create({
-  baseURL: envApiUrl || 'http://127.0.0.1:1920/api',
+  baseURL: envApiUrl || DEFAULT_API_URL,
   headers: {
     'Content-Type': 'application/json',
     'X-Client-Version': CLIENT_VERSION,
   },
 });
 
-if (!envApiUrl) {
-    discoverBackendPort().then((url) => {
-        api.defaults.baseURL = url;
-    }).catch(() => {});
-}
+api.interceptors.request.use(async (config) => {
+  try {
+    const url = await discoverBackendPort();
+    config.baseURL = url;
+  } catch {
+    config.baseURL = config.baseURL || envApiUrl || DEFAULT_API_URL;
+  }
+  return config;
+});
 
 export const PROTOCOL_URL = 'opencodestudio://launch';
 
 export const MIN_SERVER_VERSION = '2.2.2';
 
 export async function getApiBaseUrl(): Promise<string> {
-  if (api.defaults.baseURL) return api.defaults.baseURL;
   try {
     const url = await discoverBackendPort();
     api.defaults.baseURL = url;


### PR DESCRIPTION
## Summary

This PR improves the Code Settings diagnostics so users can see what the app is actually using at runtime.

## What changed

- Added a resolution context card showing:
  - live backend URL
  - active config path
  - detected config path
  - resolved Project Rules file
- Made backend URL discovery more robust so the client no longer relies on a stale default port.
- Clarified PATH-based LSP / formatter detection in the UI.

## Verification

- Confirmed in the browser that Code Settings shows:
  - the live backend URL
  - `/home/dazeb/.config/opencode/opencode.json`
  - `/home/dazeb/.config/opencode/AGENTS.md`
- Confirmed the backend resolves system tools correctly via `/api/system/tools`.

## Environment

- Reproduced and verified on **WSL2 Ubuntu 24.04**.

## Notes

This should make troubleshooting much clearer when Windows and WSL config paths differ.
