### PR TITLE
fix(next): set explicit Turbopack root

### DIFF
--- a/client-next/next.config.ts
+++ b/client-next/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
+import path from "path";
+import { fileURLToPath } from "url";
 
 const securityHeaders = [
   {
@@ -24,8 +26,14 @@ const securityHeaders = [
   },
 ];
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 const nextConfig: NextConfig = {
   output: "standalone",
+  turbopack: {
+    root: __dirname,
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary
- set `turbopack.root` explicitly in `client-next/next.config.ts`
- pin root to the `client-next` directory (`__dirname`)

## Why
Next.js detected multiple lockfiles in the repository and inferred workspace root automatically, showing a warning at startup. Explicitly setting the Turbopack root removes ambiguity and silences the warning.

## Scope
- only `client-next/next.config.ts`
