### PR TITLE
fix(usage): prevent Recharts -1 size warnings

### DIFF
--- a/client-next/src/app/usage/page.tsx
+++ b/client-next/src/app/usage/page.tsx
@@ -496,7 +496,7 @@ export default function UsagePage() {
                   </div>
                 </div>
               </div>
-              <ResponsiveContainer width="100%" height="100%">
+              <ResponsiveContainer width="100%" height={300} minWidth={0} minHeight={300}>
                 <BarChart data={stats.byDay}>
                   <CartesianGrid strokeDasharray="3 3" opacity={0.05} vertical={false} />
                   <XAxis 
@@ -605,7 +605,7 @@ export default function UsagePage() {
                   <span data-pie-value className="text-sm font-bold text-primary"></span>
                 </div>
               </div>
-              <ResponsiveContainer width="100%" height="100%">
+              <ResponsiveContainer width="100%" height={300} minWidth={0} minHeight={300}>
                 <PieChart>
                   <Pie
                     data={pieData}


### PR DESCRIPTION
## Problem
On `/usage`, Recharts logs repeated warnings in browser/dev output:

- "The width(-1) and height(-1) of chart should be greater than 0"

This happens during layout cycles where `ResponsiveContainer` resolves invalid dimensions.

## Fix
Updated `client-next/src/app/usage/page.tsx`:

- `ResponsiveContainer` for bar chart:
  - from `height="100%"`
  - to `height={300} minWidth={0} minHeight={300}`
- `ResponsiveContainer` for pie chart:
  - from `height="100%"`
  - to `height={300} minWidth={0} minHeight={300}`

## Result
Charts always receive valid dimensions, removing `-1` width/height warnings while keeping the existing UI layout.

## Validation
- `cd client-next && npm run build` passes successfully.
