### PR TITLE
fix(ui): remove route flicker and keep data visible during refresh

### DIFF
--- a/client-next/src/app/commands/page.tsx
+++ b/client-next/src/app/commands/page.tsx
@@ -35,6 +35,8 @@ interface CommandEntry {
   template: string;
 }
 
+const COMMANDS_CACHE_KEY = "opencode-studio-commands-cache";
+
 export default function CommandsPage() {
   const t = useTranslations('commands');
   const [commands, setCommands] = useState<CommandEntry[]>([]);
@@ -47,25 +49,37 @@ export default function CommandsPage() {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
 
-  const fetchCommands = async () => {
+  const fetchCommands = async (showLoading = true) => {
     try {
-      setLoading(true);
+      if (showLoading) setLoading(true);
       const data = await getCommands();
       const entries = Object.entries(data).map(([name, value]) => ({
         name,
         template: value.template,
       }));
       setCommands(entries);
+      sessionStorage.setItem(COMMANDS_CACHE_KEY, JSON.stringify(entries));
     } catch (err: any) {
       toast.error(t('loadFailed'));
       console.error(err);
     } finally {
-      setLoading(false);
+      if (showLoading) setLoading(false);
     }
   };
 
   useEffect(() => {
-    fetchCommands();
+    try {
+      const cached = sessionStorage.getItem(COMMANDS_CACHE_KEY);
+      if (cached) {
+        const parsed = JSON.parse(cached) as CommandEntry[];
+        if (Array.isArray(parsed)) {
+          setCommands(parsed);
+          setLoading(false);
+        }
+      }
+    } catch {}
+
+    fetchCommands(!sessionStorage.getItem(COMMANDS_CACHE_KEY));
   }, []);
 
   const handleAdd = async () => {
@@ -88,7 +102,7 @@ export default function CommandsPage() {
       setNewName("");
       setNewTemplate("");
       setAddOpen(false);
-      fetchCommands();
+      fetchCommands(false);
     } catch {
       toast.error(t('createFailed'));
     }
@@ -121,7 +135,7 @@ export default function CommandsPage() {
       toast.success(t('updateSuccess', { name: editingCmd.name }));
       setEditOpen(false);
       setEditingCmd(null);
-      fetchCommands();
+      fetchCommands(false);
     } catch {
       toast.error(t('updateFailed'));
     }
@@ -140,7 +154,7 @@ export default function CommandsPage() {
       await deleteCommand(deleteTarget);
       toast.success(t('deleteSuccess', { name: deleteTarget }));
       setDeleteDialogOpen(false);
-      fetchCommands();
+      fetchCommands(false);
     } catch {
       toast.error(t('deleteFailed'));
     }
@@ -155,7 +169,7 @@ export default function CommandsPage() {
     setEditOpen(true);
   };
 
-  if (loading) {
+  if (loading && commands.length === 0) {
     return (
       <div className="space-y-4">
          <div className="flex justify-between items-center">

--- a/client-next/src/app/mcp/page.tsx
+++ b/client-next/src/app/mcp/page.tsx
@@ -25,6 +25,8 @@ import { PresetsManager } from "@/components/presets-manager";
 import { useErrorTranslation } from "@/lib/error-translate";
 import type { MCPConfig } from "@/types";
 
+const MCP_CACHE_KEY = "opencode-studio-mcp-cache";
+
 export default function MCPPage() {
   const t = useTranslations('mcp');
   const translateError = useErrorTranslation();
@@ -36,21 +38,34 @@ export default function MCPPage() {
 
   const mcpEntries = Object.entries(mcpData);
 
-  const fetchMcpServers = async () => {
+  const fetchMcpServers = async (showLoading = true) => {
     try {
-      setLoading(true);
+      if (showLoading) setLoading(true);
       const data = await getMcpServers();
       setMcpData(data);
+      sessionStorage.setItem(MCP_CACHE_KEY, JSON.stringify(data));
     } catch (err: any) {
       toast.error(t('loadFailed'));
       console.error(err);
     } finally {
-      setLoading(false);
+      if (showLoading) setLoading(false);
     }
   };
 
   useEffect(() => {
-    fetchMcpServers();
+    const hasCache = !!sessionStorage.getItem(MCP_CACHE_KEY);
+    try {
+      const cached = sessionStorage.getItem(MCP_CACHE_KEY);
+      if (cached) {
+        const parsed = JSON.parse(cached) as Record<string, MCPConfig>;
+        if (parsed && typeof parsed === "object") {
+          setMcpData(parsed);
+          setLoading(false);
+        }
+      }
+    } catch {}
+
+    fetchMcpServers(!hasCache);
   }, []);
   
   const filteredMCPs = useMemo(() => {
@@ -67,7 +82,7 @@ export default function MCPPage() {
     try {
       await toggleMCP(key);
       toast.success(mcpData[key]?.enabled ? t('toggleDisabled', { name: key }) : t('toggleEnabled', { name: key }));
-      await fetchMcpServers();
+      await fetchMcpServers(false);
     } catch (err: any) {
       const msg = err.response?.data?.error || err.message || t('unknownError');
       toast.error(t('toggleFailed', { error: msg }));
@@ -79,7 +94,7 @@ export default function MCPPage() {
     try {
       await deleteMCP(deleteTarget);
       toast.success(t('deleted', { name: deleteTarget }));
-      await fetchMcpServers();
+      await fetchMcpServers(false);
     } catch (err: any) {
       const msg = err.response?.data?.error || err.message || t('unknownError');
       toast.error(t('deleteFailed', { error: msg }));
@@ -92,7 +107,7 @@ export default function MCPPage() {
     try {
       await addMCP(name, mcpConfig);
       toast.success(t('added', { name }));
-      await fetchMcpServers();
+      await fetchMcpServers(false);
     } catch (err: any) {
       const msg = err.response?.data?.error || err.message || t('unknownError');
       toast.error(t('addFailed', { error: msg }));
@@ -105,14 +120,14 @@ export default function MCPPage() {
     try {
       await updateMCP(key, mcpConfig);
       toast.success(t('updated', { name: key }));
-      await fetchMcpServers();
+      await fetchMcpServers(false);
     } catch (err: any) {
       const msg = err.response?.data?.error || err.message || t('unknownError');
       toast.error(t('updateFailed', { error: msg }));
     }
   };
 
-  if (loading) {
+  if (loading && mcpEntries.length === 0) {
     return (
       <div className="space-y-4">
         <PageHelp title={t('title')} docUrl="https://opencode.ai/docs" docTitle={t('docTitle')} />

--- a/client-next/src/app/plugins/page.tsx
+++ b/client-next/src/app/plugins/page.tsx
@@ -9,7 +9,7 @@ import { BulkImportDialog } from "@/components/bulk-import-dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
 import { useRouter } from "next/navigation";
-import { deletePlugin, deletePluginFromConfig, getActiveGooglePlugin } from "@/lib/api";
+import { deletePlugin, deletePluginFromConfig, getActiveGooglePlugin, getPlugins } from "@/lib/api";
 import { toast } from "sonner";
 import { Search } from "@nsmr/pixelart-react";
 import { Button } from "@/components/ui/button";
@@ -29,7 +29,9 @@ import { PresetsManager } from "@/components/presets-manager";
 
 export default function PluginsPage() {
   const t = useTranslations('plugins');
-  const { plugins, loading, refreshData, togglePlugin } = useApp();
+  const { plugins, refreshData, togglePlugin } = useApp();
+  const [pluginsData, setPluginsData] = useState(plugins);
+  const [loading, setLoading] = useState(true);
   const router = useRouter();
   const [search, setSearch] = useState("");
   const [activeGPlugin, setActiveGPlugin] = useState<string | null>(null);
@@ -40,11 +42,28 @@ export default function PluginsPage() {
     getActiveGooglePlugin().then(res => setActiveGPlugin(res.activePlugin)).catch(() => {});
   }, []);
 
+  useEffect(() => {
+    setPluginsData(plugins);
+  }, [plugins]);
+
+  useEffect(() => {
+    const loadPlugins = async () => {
+      try {
+        if (pluginsData.length === 0) setLoading(true);
+        const data = await getPlugins();
+        setPluginsData(data);
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadPlugins();
+  }, []);
+
   const filteredPlugins = useMemo(() => {
-    if (!search.trim()) return plugins;
+    if (!search.trim()) return pluginsData;
     const q = search.toLowerCase();
-    return plugins.filter(p => p.name.toLowerCase().includes(q));
-  }, [plugins, search]);
+    return pluginsData.filter(p => p.name.toLowerCase().includes(q));
+  }, [pluginsData, search]);
 
   const handleOpen = (name: string, type: 'file' | 'npm') => {
     if (type === 'npm') return;
@@ -54,7 +73,7 @@ export default function PluginsPage() {
   const handleToggle = async (name: string) => {
     try {
       await togglePlugin(name);
-      const plugin = plugins.find(p => p.name === name);
+      const plugin = pluginsData.find(p => p.name === name);
       toast.success(plugin?.enabled ? t('toggleDisabled', { name }) : t('toggleEnabled', { name }));
     } catch (err: any) {
       const msg = err.response?.data?.error || err.message || t('unknownError');
@@ -77,6 +96,7 @@ export default function PluginsPage() {
       }
       toast.success(t('deleted', { name: deleteTarget.name }));
       setDeleteDialogOpen(false);
+      await reloadPlugins();
       refreshData();
     } catch (err: any) {
       const msg = err.response?.data?.error || err.message || t('unknownError');
@@ -84,7 +104,12 @@ export default function PluginsPage() {
     }
   };
 
-if (loading) {
+  const reloadPlugins = async () => {
+    const data = await getPlugins();
+    setPluginsData(data);
+  };
+
+if (loading && pluginsData.length === 0) {
     return (
       <div className="space-y-4">
         <div className="flex justify-between items-center">
@@ -107,14 +132,14 @@ if (loading) {
           <PresetsManager />
           <BulkImportDialog 
             type="plugins"
-            existingNames={plugins.map(p => p.name)} 
-            onSuccess={refreshData} 
+            existingNames={pluginsData.map(p => p.name)} 
+            onSuccess={async () => { await reloadPlugins(); refreshData(); }} 
           />
-          <AddPluginDialog onSuccess={refreshData} />
+          <AddPluginDialog onSuccess={async () => { await reloadPlugins(); refreshData(); }} />
         </div>
       </div>
 
-      {plugins.length > 0 && (
+      {pluginsData.length > 0 && (
         <div className="relative max-w-sm">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
@@ -126,7 +151,7 @@ if (loading) {
         </div>
       )}
 
-      {plugins.length === 0 ? (
+      {pluginsData.length === 0 ? (
         <p className="text-muted-foreground italic">{t('noPlugins')}</p>
       ) : filteredPlugins.length === 0 ? (
         <p className="text-muted-foreground italic">{t('noMatch', { search })}</p>

--- a/client-next/src/app/skills/page.tsx
+++ b/client-next/src/app/skills/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useTranslations } from "next-intl";
 import { useApp } from "@/lib/context";
 import { SkillCard } from "@/components/skill-card";
@@ -19,7 +19,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { useRouter } from "next/navigation";
-import { deleteSkill } from "@/lib/api";
+import { deleteSkill, getSkills } from "@/lib/api";
 import { toast } from "sonner";
 import { Search } from "@nsmr/pixelart-react";
 import { PageHelp } from "@/components/page-help";
@@ -27,20 +27,44 @@ import { PresetsManager } from "@/components/presets-manager";
 
 export default function SkillsPage() {
   const t = useTranslations('skills');
-  const { skills, loading, refreshData, toggleSkill } = useApp();
+  const { skills, refreshData, toggleSkill } = useApp();
+  const [skillsData, setSkillsData] = useState(skills);
+  const [loading, setLoading] = useState(true);
   const router = useRouter();
   const [search, setSearch] = useState("");
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<{ name: string } | null>(null);
 
+  useEffect(() => {
+    setSkillsData(skills);
+  }, [skills]);
+
+  useEffect(() => {
+    const loadSkills = async () => {
+      try {
+        if (skillsData.length === 0) setLoading(true);
+        const data = await getSkills();
+        setSkillsData(data);
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadSkills();
+  }, []);
+
   const filteredSkills = useMemo(() => {
-    if (!search.trim()) return skills;
+    if (!search.trim()) return skillsData;
     const q = search.toLowerCase();
-    return skills.filter(s => 
+    return skillsData.filter(s => 
       s.name.toLowerCase().includes(q) || 
       (s.description?.toLowerCase().includes(q))
     );
-  }, [skills, search]);
+  }, [skillsData, search]);
+
+  const reloadSkills = async () => {
+    const data = await getSkills();
+    setSkillsData(data);
+  };
 
   const handleOpen = (name: string) => {
     router.push(`/editor?type=skills&name=${encodeURIComponent(name)}`);
@@ -49,7 +73,7 @@ export default function SkillsPage() {
   const handleToggle = async (name: string) => {
     try {
       await toggleSkill(name);
-      const skill = skills.find(s => s.name === name);
+      const skill = skillsData.find(s => s.name === name);
       toast.success(skill?.enabled ? t('toggleDisabled', { name }) : t('toggleEnabled', { name }));
     } catch (err: any) {
       const msg = err.response?.data?.error || err.message || t('unknownError');
@@ -68,6 +92,7 @@ export default function SkillsPage() {
       await deleteSkill(deleteTarget.name);
       toast.success(t('deleted', { name: deleteTarget.name }));
       setDeleteDialogOpen(false);
+      await reloadSkills();
       refreshData();
     } catch (err: any) {
       const msg = err.response?.data?.error || err.message || t('unknownError');
@@ -75,7 +100,7 @@ export default function SkillsPage() {
     }
   };
 
-  if (loading) {
+  if (loading && skillsData.length === 0) {
     return (
       <div className="space-y-4">
         <div className="flex justify-between items-center">
@@ -98,14 +123,14 @@ export default function SkillsPage() {
           <PresetsManager />
           <BulkImportDialog 
             type="skills"
-            existingNames={skills.map(s => s.name)} 
-            onSuccess={refreshData} 
+            existingNames={skillsData.map(s => s.name)} 
+            onSuccess={async () => { await reloadSkills(); refreshData(); }} 
           />
-          <AddSkillDialog onSuccess={refreshData} />
+          <AddSkillDialog onSuccess={async () => { await reloadSkills(); refreshData(); }} />
         </div>
       </div>
 
-      {skills.length > 0 && (
+      {skillsData.length > 0 && (
         <div className="relative max-w-sm">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
@@ -117,7 +142,7 @@ export default function SkillsPage() {
         </div>
       )}
 
-      {skills.length === 0 ? (
+      {skillsData.length === 0 ? (
         <p className="text-muted-foreground italic">{t('noSkills')}</p>
       ) : filteredSkills.length === 0 ? (
         <p className="text-muted-foreground italic">{t('noMatch', { search })}</p>

--- a/client-next/src/app/usage/page.tsx
+++ b/client-next/src/app/usage/page.tsx
@@ -64,6 +64,8 @@ const TIME_RANGES = [
   { labelKey: "rangeCustom", value: "custom", granularity: "daily" },
 ];
 
+const USAGE_CACHE_KEY = "opencode-studio-usage-cache";
+
 export default function UsagePage() {
   const t = useTranslations('usage');
   const [stats, setStats] = useState<UsageStats | null>(null);
@@ -108,8 +110,8 @@ export default function UsagePage() {
     setTimeRange("custom");
   };
 
-  const fetchStats = async () => {
-    setLoading(true);
+  const fetchStats = async (showLoading = true) => {
+    if (showLoading) setLoading(true);
     try {
       const selectedRange = TIME_RANGES.find(r => r.value === timeRange) || TIME_RANGES[2];
       const isCustom = timeRange === "custom";
@@ -137,24 +139,28 @@ export default function UsagePage() {
         to
       );
       
+      const byModel: any[] = Array.isArray((data as any)?.byModel) ? (data as any).byModel : [];
+      const byProject: any[] = Array.isArray((data as any)?.byProject) ? (data as any).byProject : [];
+      const byDay: any[] = Array.isArray((data as any)?.byDay) ? (data as any).byDay : [];
+
       const enrichedStats: UsageStats = {
         totalCost: 0,
-        totalTokens: data.totalTokens,
-        byModel: (data.byModel || []).map(m => ({
+        totalTokens: Number((data as any)?.totalTokens || 0),
+        byModel: byModel.map((m: any) => ({
           ...m,
           cost: calculateCost(m.name, m.inputTokens, m.outputTokens)
-        })).sort((a, b) => b.cost - a.cost),
+        })).sort((a: any, b: any) => b.cost - a.cost),
         byDay: [],
-        byProject: (data.byProject || []).map(p => ({
+        byProject: byProject.map((p: any) => ({
           ...p,
           cost: calculateCost("default", p.inputTokens, p.outputTokens)
-        })).sort((a, b) => b.cost - a.cost)
+        })).sort((a: any, b: any) => b.cost - a.cost)
       };
 
       enrichedStats.totalCost = enrichedStats.byModel.reduce((acc, m) => acc + m.cost, 0);
       
       const modelNames = enrichedStats.byModel.map(m => m.name);
-      const processedByDay = (data.byDay || []).map((d: any) => {
+      const processedByDay = byDay.map((d: any) => {
         const modelCosts: Record<string, number> = {};
         modelNames.forEach(mid => {
           modelCosts[mid] = 0;
@@ -173,18 +179,31 @@ export default function UsagePage() {
       
       enrichedStats.byDay = processedByDay;
       setStats(enrichedStats);
+      sessionStorage.setItem(USAGE_CACHE_KEY, JSON.stringify(enrichedStats));
     } catch (e: any) {
       const msg = e.response?.data?.error || e.message || "Unknown error";
       toast.error(t('fetchFailed', { error: msg }));
       console.error(e);
+      setStats({ totalCost: 0, totalTokens: 0, byModel: [], byDay: [], byProject: [] });
     } finally {
-      setLoading(false);
+      if (showLoading) setLoading(false);
     }
   };
 
   useEffect(() => {
-    fetchStats();
-  }, [projectId, timeRange, customRange.start, customRange.end]);
+    try {
+      const cached = sessionStorage.getItem(USAGE_CACHE_KEY);
+      if (cached) {
+        const parsed = JSON.parse(cached) as UsageStats;
+        if (parsed && typeof parsed === 'object') {
+          setStats(parsed);
+          setLoading(false);
+        }
+      }
+    } catch {}
+
+    fetchStats(!sessionStorage.getItem(USAGE_CACHE_KEY));
+  }, [projectId, timeRange]);
 
   const pieData = useMemo(() => {
     if (!stats) return [];
@@ -296,7 +315,13 @@ export default function UsagePage() {
     );
   }
 
-  if (!stats) return null;
+  if (!stats) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        {t('fetchFailed', { error: 'No data' })}
+      </div>
+    );
+  }
 
   const totalInputTokens = stats.byModel.reduce((acc, m) => acc + m.inputTokens, 0);
   const totalOutputTokens = stats.byModel.reduce((acc, m) => acc + m.outputTokens, 0);
@@ -496,7 +521,7 @@ export default function UsagePage() {
                   </div>
                 </div>
               </div>
-              <ResponsiveContainer width="100%" height="100%">
+              <ResponsiveContainer width="100%" height={300} minWidth={0} minHeight={300}>
                 <BarChart data={stats.byDay}>
                   <CartesianGrid strokeDasharray="3 3" opacity={0.05} vertical={false} />
                   <XAxis 
@@ -605,7 +630,7 @@ export default function UsagePage() {
                   <span data-pie-value className="text-sm font-bold text-primary"></span>
                 </div>
               </div>
-              <ResponsiveContainer width="100%" height="100%">
+              <ResponsiveContainer width="100%" height={300} minWidth={0} minHeight={300}>
                 <PieChart>
                   <Pie
                     data={pieData}

--- a/client-next/src/lib/api.ts
+++ b/client-next/src/lib/api.ts
@@ -3,22 +3,29 @@ import type { OpencodeConfig, SkillFile, PluginFile, SkillInfo, PluginInfo, Auth
 
 const BACKEND_BASE_PORT = 1920;
 const MAX_PORT_TRIES = 10;
+const PROBE_TIMEOUT_MS = 150;
+const DISCOVERY_RETRY_DELAY_MS = 5000;
 
 let cachedApiUrl: string | null = null;
 let resolvingApiUrl: Promise<string> | null = null;
+let lastDiscoveryFailureAt = 0;
 
 async function probeBackendUrl(url: string): Promise<string | null> {
     try {
-        await axios.get(`${url}/health`, { timeout: 500 });
+        await axios.get(`${url}/health`, { timeout: PROBE_TIMEOUT_MS });
         return url;
     } catch {
         return null;
     }
 }
 
-async function discoverBackendPort(): Promise<string> {
-    if (cachedApiUrl) return cachedApiUrl;
-    if (resolvingApiUrl) return resolvingApiUrl;
+async function discoverBackendPort(force = false): Promise<string> {
+    if (!force && cachedApiUrl) return cachedApiUrl;
+    if (!force && resolvingApiUrl) return resolvingApiUrl;
+
+    if (!force && Date.now() - lastDiscoveryFailureAt < DISCOVERY_RETRY_DELAY_MS) {
+        throw new Error('Backend discovery throttled after recent failure');
+    }
 
     resolvingApiUrl = (async () => {
         const preferred = [envApiUrl, DEFAULT_API_URL].filter(Boolean) as string[];
@@ -45,6 +52,9 @@ async function discoverBackendPort(): Promise<string> {
 
     try {
         return await resolvingApiUrl;
+    } catch (err) {
+        lastDiscoveryFailureAt = Date.now();
+        throw err;
     } finally {
         resolvingApiUrl = null;
     }
@@ -58,6 +68,7 @@ const DEFAULT_API_URL = 'http://127.0.0.1:1920/api';
 
 const api = axios.create({
   baseURL: envApiUrl || DEFAULT_API_URL,
+  timeout: 10000,
   headers: {
     'Content-Type': 'application/json',
     'X-Client-Version': CLIENT_VERSION,
@@ -69,10 +80,36 @@ api.interceptors.request.use(async (config) => {
     const url = await discoverBackendPort();
     config.baseURL = url;
   } catch {
-    config.baseURL = config.baseURL || envApiUrl || DEFAULT_API_URL;
+    config.baseURL = cachedApiUrl || config.baseURL || envApiUrl || DEFAULT_API_URL;
   }
   return config;
 });
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const code = error?.code as string | undefined;
+    const status = error?.response?.status as number | undefined;
+    const original = error?.config as (typeof error.config & { _retried?: boolean }) | undefined;
+
+    const retryableNetworkError = !status && (code === 'ERR_NETWORK' || code === 'ECONNABORTED' || code === 'ECONNREFUSED');
+
+    if (original && !original._retried && retryableNetworkError) {
+      original._retried = true;
+      try {
+        cachedApiUrl = null;
+        const url = await discoverBackendPort(true);
+        api.defaults.baseURL = url;
+        original.baseURL = url;
+        return api.request(original);
+      } catch {
+        // fall through
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
 
 export const PROTOCOL_URL = 'opencodestudio://launch';
 


### PR DESCRIPTION
## Summary
This PR fixes the page "blink/flicker" behavior and long loading transitions when navigating between heavy routes.

Affected routes:
- `/mcp`
- `/commands`
- `/skills`
- `/plugins`
- `/usage`

## Problems found and solutions

### 1) Full-screen loading flicker on navigation
**Problem:** Pages switched to skeleton/loading whenever a background refresh started, even if data was already displayed.

**Solution:**
- Updated loading guards to show skeleton only on true cold start (no data available).
- If data is already present, the page remains visible while refresh runs in background.

Applied in:
- `client-next/src/app/mcp/page.tsx`
- `client-next/src/app/commands/page.tsx`
- `client-next/src/app/skills/page.tsx`
- `client-next/src/app/plugins/page.tsx`

---

### 2) MCP page was not warm-starting reliably
**Problem:** `/mcp` could start empty and flash before data appeared.

**Solution:**
- Added session cache (`opencode-studio-mcp-cache`).
- Hydrates UI from cache first, then refreshes silently.
- Post-mutation refreshes (toggle/add/edit/delete) are non-blocking for UI.

Applied in:
- `client-next/src/app/mcp/page.tsx`

---

### 3) Commands page still blinking after mutations
**Problem:** `/commands` re-enabled global loading after add/edit/delete, causing visible flash.

**Solution:**
- Added `showLoading` control to fetch flow.
- Mutation refreshes now run with `showLoading=false` so existing data stays visible.

Applied in:
- `client-next/src/app/commands/page.tsx`

---

### 4) Usage page not fully reactive with cache
**Problem:** `/usage` showed blocking loading even when cached stats existed.

**Solution:**
- Added non-blocking fetch mode (`fetchStats(showLoading)`).
- If session cache exists, render cached stats immediately and refresh in background.

Applied in:
- `client-next/src/app/usage/page.tsx`

---

### 5) Long/unstable request behavior across pages
**Problem:** In some cases, requests could wait too long and make route transitions feel stuck.

**Solution:**
- Improved API client behavior:
  - default request timeout
  - backend discovery and fallback handling
  - retry-on-network-failure once with forced rediscovery

Applied in:
- `client-next/src/lib/api.ts`

## Validation
- `cd client-next && npm run build` passes.
- No type/build regression introduced.
