### PR TITLE
fix(usage): add missing time range i18n keys

### DIFF
--- a/client-next/messages/en.json
+++ b/client-next/messages/en.json
@@ -605,6 +605,13 @@
     "templatePythonDesc": "Rules for Python projects"
   },
   "usage": {
+    "range24h": "Last 24h",
+    "range7d": "Last 7d",
+    "range30d": "Last 30d",
+    "range3m": "Last 3m",
+    "range6m": "Last 6m",
+    "range1y": "Last 1y",
+    "rangeCustom": "Custom",
     "selectBothDates": "Select both start and end dates.",
     "startDateBefore": "Start date must be before end date.",
     "fetchFailed": "Failed to fetch usage stats: {error}",

--- a/client-next/messages/zh-CN.json
+++ b/client-next/messages/zh-CN.json
@@ -609,6 +609,13 @@
     "templatePythonDesc": "\u9002\u7528\u4e8e Python \u9879\u76ee"
   },
   "usage": {
+    "range24h": "最近24小时",
+    "range7d": "最近7天",
+    "range30d": "最近30天",
+    "range3m": "最近3个月",
+    "range6m": "最近6个月",
+    "range1y": "最近1年",
+    "rangeCustom": "自定义",
     "selectBothDates": "\u8bf7\u9009\u62e9\u5f00\u59cb\u548c\u7ed3\u675f\u65e5\u671f\u3002",
     "startDateBefore": "\u5f00\u59cb\u65e5\u671f\u5fc5\u987b\u65e9\u4e8e\u7ed3\u675f\u65e5\u671f\u3002",
     "fetchFailed": "\u83b7\u53d6\u4f7f\u7528\u7edf\u8ba1\u5931\u8d25: {error}",


### PR DESCRIPTION
## Summary
- Adds missing `usage` translation keys used by the Usage page time-range selector.
- Fixes `MISSING_MESSAGE` runtime errors for `usage.range24h`, `usage.range7d`, `usage.range30d`, `usage.range3m`, `usage.range6m`, `usage.range1y`, and `usage.rangeCustom`.
- Updates both English and Chinese locale files to keep language coverage aligned.

## Why
The `/usage` page renders `t(r.labelKey)` for each predefined time range. These keys were absent from locale messages, causing repeated console/runtime errors in Next.js.

## Files
- `client-next/messages/en.json`
- `client-next/messages/zh-CN.json`