### PR TITLE
fix(logs): show recent entries immediately on /logs

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -243,8 +243,14 @@ function setupLogWatcher() {
             fileSize = fs.statSync(filePath).size;
         } catch {}
 
-        // Tail from end initially
-        let start = Math.max(0, fileSize - 10000); 
+        // Tail from end initially so /logs isn't empty on first connect
+        const start = Math.max(0, fileSize - 10000);
+        if (fileSize > 0) {
+            try {
+                const initialChunk = fs.readFileSync(filePath, 'utf8').slice(start);
+                initialChunk.split('\n').forEach(processLogLine);
+            } catch {}
+        }
         
         const checkFile = () => {
             try {
@@ -257,8 +263,7 @@ function setupLogWatcher() {
                     });
                     
                     stream.on('data', (chunk) => {
-                        const lines = chunk.split('\n');
-                        lines.forEach(processLogLine);
+                        chunk.split('\n').forEach(processLogLine);
                     });
                     
                     fileSize = stat.size;


### PR DESCRIPTION
## Problem
The `/logs` screen connected successfully to the SSE endpoint (`/api/logs/stream`), but it often displayed **no logs** when opened.

This happened because the watcher only emitted events when the log file size increased. So if logs already existed in the current file but no new lines were written at that moment, the UI stayed empty.

## Root cause
In `setupLogWatcher()` (`server/index.js`):
- the initial tail offset (`start = Math.max(0, fileSize - 10000)`) was computed,
- but that initial chunk was never read or queued,
- and streaming only started for future file growth (`stat.size > fileSize`).

## Fix implemented
- Read the initial tail (last ~10KB) immediately when tailing starts for the current log file,
- Feed that initial content through `processLogLine` so SSE subscribers receive immediate history,
- Keep the existing incremental stream behavior for newly appended lines,
- Slightly simplify chunk line processing without changing behavior.

## Files changed
- `server/index.js`
  - added initial log chunk preload in `startTailing()`,
  - queued those lines for buffer/subscribers,
  - simplified `stream.on('data')` line splitting.

## Expected result
When opening `/logs`, users now see recent existing entries from the active log file right away, instead of waiting for new log events to appear.