### PR TITLE
fix: publish server from server/ directory to include dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "server": "cd server && npm start",
     "client": "cd client-next && npm run dev",
     "build": "cd client-next && npm run build",
-    "postinstall": "cd server && npm install && cd ../client-next && npm install"
+    "postinstall": "cd server && npm install && cd ../client-next && npm install",
+    "release-server": "cd server && npm publish"
   },
   "dependencies": {
     "concurrently": "^8.2.2"

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-studio-server",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Backend server for OpenCode Studio - manages opencode configurations",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Fixes the missing 'express' module error reported in #39. 

The root package.json was being published, but it lacked the server dependencies. Now:
-  version is synced with root.
- Added 
> opencode-studio-server@2.3.0 release-server
> cd server && npm publish script to root to ensure publish happens from the  directory.
- This ensures all dependencies listed in  (express, cors, etc.) are correctly bundled in the published npm package.