### PR TITLE
fix(server): declare missing jsonc-parser dependency

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,7 @@
     "body-parser": "^2.2.1",
     "cors": "^2.8.5",
     "express": "^5.2.1",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.1.1",
+    "jsonc-parser": "^3.3.1"
   }
 }


### PR DESCRIPTION
After 2.3.2 the package installs cleanly, but the server crashes on first start:

    Error: Cannot find module 'jsonc-parser'
    Require stack:
      - server/lib/config-providers.js
      - server/index.js
      - server/cli.js

`server/lib/config-providers.js` requires `jsonc-parser` (used to parse 
`opencode.jsonc` / `oh-my-openagent.jsonc` etc.) but the dependency is not 
declared in `server/package.json`. It only worked locally because something 
else in the workspace was pulling it in transitively.

This adds it explicitly so `npm install -g opencode-studio-server` produces a 
runnable server.

Verified:
  - `npm pack` + `npm install` of the resulting tarball
  - `opencode-studio-server` → `Server running at http://localhost:1920`

Repro env: Node 25.9.0, npm 11.14.1, macOS.

Refs #39