### PR TITLE
fix: prevent greedy sidebar active state for nested routes

### DIFF
--- a/client-next/src/components/sidebar.tsx
+++ b/client-next/src/components/sidebar.tsx
@@ -74,7 +74,15 @@ export function Sidebar() {
 
         <nav className="flex-1 py-4 space-y-0.5">
           {navItems.map((item) => {
-            const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
+            const isActive = (() => {
+              if (pathname === item.href) return true;
+              if (!pathname.startsWith(`${item.href}/`)) return false;
+              // Check if a more specific nav item matches instead
+              const hasMoreSpecificMatch = navItems.some(
+                (other) => other.href !== item.href && other.href.startsWith(`${item.href}/`) && (pathname === other.href || pathname.startsWith(`${other.href}/`))
+              );
+              return !hasMoreSpecificMatch;
+            })();
             return (
               <Tooltip key={item.href}>
                 <TooltipTrigger asChild>


### PR DESCRIPTION
## Fix for #44

**Problem:** When navigating to `/settings/code`, both "Code Settings" and "Settings" highlight in the sidebar because `/settings/code`.startsWith(`/settings/`) is true.

**Fix:** The `isActive` check now also verifies that no more specific nav item matches the current path before marking a parent route as active. This prevents `/settings` from being highlighted when the user is actually on `/settings/code`.

**Changes:**
- `client-next/src/components/sidebar.tsx` — replaced greedy `startsWith` with specificity-aware active check

Closes #44