### PR TITLE
fix(server): validate config resource names

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -14,6 +14,7 @@ const { corsOptions, setLocalNetworkAccessHeaders } = require('./lib/cors-policy
 const {
     assertSafeBackupResourceNames,
     isSafeAgentName,
+    isSafeAuthProfileName,
     isSafePluginName,
     isSafeSkillName,
 } = require('./lib/resource-names');
@@ -47,6 +48,7 @@ const ERROR_CODES = {
   NO_CONFIG_FOR_PLUGIN: "No active config to create plugin",
   NO_AUTH_FOR_PROVIDER: "No current auth for provider",
   PROFILE_NOT_FOUND: "Profile not found",
+  INVALID_AUTH_PROFILE_NAME: "Invalid auth profile name",
   FAILED_OPEN_TERMINAL: "Failed to open terminal",
   NO_TERMINAL: "No terminal emulator found",
   NO_ACCOUNTS_IN_POOL: "No accounts in pool",
@@ -3608,6 +3610,12 @@ const listAuthProfiles = (p, activePlugin) => {
     } catch { return []; }
 };
 
+function rejectInvalidAuthProfileName(res, name) {
+    if (isSafeAuthProfileName(name)) return false;
+    res.status(400).json({ error: ERROR_CODES.INVALID_AUTH_PROFILE_NAME, code: 'INVALID_AUTH_PROFILE_NAME' });
+    return true;
+}
+
 app.get('/api/auth/providers', (req, res) => {
     const providers = [
         { id: 'google', name: 'Google', type: 'oauth', description: 'Google Gemini API' },
@@ -3739,6 +3747,7 @@ app.post('/api/auth/profiles/:provider', (req, res) => {
     }
 
     const profileName = name || auth[provider].email || `profile-${Date.now()}`;
+    if (rejectInvalidAuthProfileName(res, profileName)) return;
     const profilePath = path.join(dir, `${profileName}.json`);
     atomicWriteFileSync(profilePath, JSON.stringify(auth[provider], null, 2));
 
@@ -3763,6 +3772,7 @@ app.post('/api/auth/profiles/:provider/:name/activate', (req, res) => {
         ? ('google.antigravity')
         : provider;
     
+    if (rejectInvalidAuthProfileName(res, name)) return;
     const dir = getProfileDir(provider, activePlugin);
     const profilePath = path.join(dir, `${name}.json`);
     if (!fs.existsSync(profilePath)) return res.status(404).json({ error: ERROR_CODES.PROFILE_NOT_FOUND, code: 'PROFILE_NOT_FOUND' });
@@ -3879,6 +3889,7 @@ app.delete('/api/auth/profiles/:provider/:name', (req, res) => {
         ? ('google.antigravity')
         : provider;
     
+    if (rejectInvalidAuthProfileName(res, name)) return;
     const dir = getProfileDir(provider, activePlugin);
     const profilePath = path.join(dir, `${name}.json`);
     console.log(`[Auth] Target path: ${profilePath}, Exists: ${fs.existsSync(profilePath)}`);
@@ -3992,6 +4003,8 @@ app.put('/api/auth/profiles/:provider/:name', (req, res) => {
         ? ('google.antigravity')
         : provider;
     
+    if (rejectInvalidAuthProfileName(res, name)) return;
+    if (rejectInvalidAuthProfileName(res, newName)) return;
     const dir = getProfileDir(provider, activePlugin);
     const oldPath = path.join(dir, `${name}.json`);
     const newPath = path.join(dir, `${newName}.json`);
@@ -4220,6 +4233,10 @@ function importCurrentAuthToPool(provider) {
     }
 
     const name = email || creds.accountId || creds.id || 'primary';
+    if (!isSafeAuthProfileName(name)) {
+        console.warn(`[Auth] Skipping ${provider} pool sync for invalid profile name.`);
+        return;
+    }
     const profileDir = path.join(AUTH_PROFILES_DIR, provider);
     if (!fs.existsSync(profileDir)) fs.mkdirSync(profileDir, { recursive: true });
 
@@ -4279,6 +4296,10 @@ function importCurrentGoogleAuthToPool() {
     if (!fs.existsSync(profileDir)) fs.mkdirSync(profileDir, { recursive: true });
 
     const email = creds.email;
+    if (!isSafeAuthProfileName(email)) {
+        console.warn('[Auth] Skipping Google pool sync for invalid profile name.');
+        return;
+    }
     const profilePath = path.join(profileDir, `${email}.json`);
 
     // Check if we need to sync (new account or updated tokens/metadata)
@@ -4373,6 +4394,10 @@ function syncAntigravityPool() {
     const seen = new Set();
     allAccounts.forEach((account, idx) => {
         const name = account.email || `account-${idx + 1}`;
+        if (!isSafeAuthProfileName(name)) {
+            console.warn('[Pool] Skipping Antigravity account with invalid profile name.');
+            return;
+        }
         seen.add(name);
         const profilePath = path.join(profileDir, `${name}.json`);
         if (!fs.existsSync(profilePath)) {
@@ -4635,6 +4660,8 @@ app.put('/api/auth/pool/:name/cooldown', (req, res) => {
     const { name } = req.params;
     let { duration, provider = 'google', rule } = req.body;
     
+    if (rejectInvalidAuthProfileName(res, name)) return;
+
     if (rule) {
         const studio = loadStudioConfig();
         const r = (studio.cooldownRules || []).find(cr => cr.name === rule);
@@ -4666,6 +4693,8 @@ app.delete('/api/auth/pool/:name/cooldown', (req, res) => {
     const { name } = req.params;
     const provider = req.query.provider || 'google';
     
+    if (rejectInvalidAuthProfileName(res, name)) return;
+
     const activePlugin = getActiveGooglePlugin();
     const namespace = provider === 'google'
         ? ('google.antigravity')
@@ -4685,6 +4714,8 @@ app.post('/api/auth/pool/:name/usage', (req, res) => {
     const { name } = req.params;
     const { provider = 'google' } = req.body;
     
+    if (rejectInvalidAuthProfileName(res, name)) return;
+
     const activePlugin = getActiveGooglePlugin();
     const namespace = provider === 'google'
         ? ('google.antigravity')
@@ -4712,6 +4743,8 @@ app.put('/api/auth/pool/:name/metadata', (req, res) => {
     const { name } = req.params;
     const { provider = 'google', email, createdAt, projectId, tier } = req.body;
     
+    if (rejectInvalidAuthProfileName(res, name)) return;
+
     const activePlugin = getActiveGooglePlugin();
     const namespace = provider === 'google'
         ? ('google.antigravity')
@@ -5260,6 +5293,9 @@ app.post('/api/auth/google/start', async (req, res) => {
             const profileDir = path.join(AUTH_PROFILES_DIR, namespace);
             if (!fs.existsSync(profileDir)) fs.mkdirSync(profileDir, { recursive: true });
             const profileName = email || `google-${Date.now()}`;
+            if (!isSafeAuthProfileName(profileName)) {
+                throw new Error('Invalid auth profile name');
+            }
             const profilePath = path.join(profileDir, `${profileName}.json`);
             
             console.log(`[Auth] Saving profile to: ${profilePath}`);

--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,12 @@ const { spawn, exec, execSync } = require('child_process');
 const yaml = require('js-yaml');
 const configProviders = require('./lib/config-providers');
 const { corsOptions, setLocalNetworkAccessHeaders } = require('./lib/cors-policy');
+const {
+    assertSafeBackupResourceNames,
+    isSafeAgentName,
+    isSafePluginName,
+    isSafeSkillName,
+} = require('./lib/resource-names');
 
 const pkg = require('./package.json');
 const profileManager = require('./profile-manager');
@@ -22,6 +28,7 @@ const ERROR_CODES = {
   INVALID_PERMISSION: "Invalid permission value. Must be ask, allow, or deny.",
   MISSING_AGENT_NAME: "Missing agent name",
   INVALID_AGENT_NAME: "Invalid agent name",
+  INVALID_PLUGIN_NAME: "Invalid plugin name",
   NO_CONFIG_PATH: "No config path found",
   INVALID_NAME_OR_DURATION: "Invalid name or duration",
   INVALID_STATE: "Invalid state",
@@ -68,6 +75,14 @@ function compareVersions(current, minimum) {
         if (cv < mv) return -1;
     }
     return 0;
+}
+
+function sendErrorResponse(res, err) {
+    const status = err.statusCode || err.status || 500;
+    res.status(status).json({
+        error: err.message,
+        ...(err.code && { code: err.code }),
+    });
 }
 
 // Atomic file write: write to temp file then rename to prevent corruption
@@ -1496,7 +1511,7 @@ app.post('/api/agents', (req, res) => {
     try {
         const { name, config: agentConfig, source, scope } = req.body || {};
         if (!name || typeof name !== 'string') return res.status(400).json({ error: ERROR_CODES.MISSING_AGENT_NAME, code: 'MISSING_AGENT_NAME' });
-        if (!/^[a-zA-Z0-9 _-]+$/.test(name)) return res.status(400).json({ error: ERROR_CODES.INVALID_AGENT_NAME, code: 'INVALID_AGENT_NAME' });
+        if (!isSafeAgentName(name)) return res.status(400).json({ error: ERROR_CODES.INVALID_AGENT_NAME, code: 'INVALID_AGENT_NAME' });
 
         const config = loadConfig() || {};
         if (!config.agent) config.agent = {};
@@ -1551,6 +1566,9 @@ app.put('/api/agents/:name', (req, res) => {
     try {
         const { name } = req.params;
         const { config: agentConfig } = req.body || {};
+        if (!isSafeAgentName(name)) {
+            return res.status(400).json({ error: ERROR_CODES.INVALID_AGENT_NAME, code: 'INVALID_AGENT_NAME' });
+        }
 
         const normalizedConfig = { ...(agentConfig || {}) };
         if (normalizedConfig.permissions && !normalizedConfig.permission) {
@@ -1595,6 +1613,10 @@ app.put('/api/agents/:name', (req, res) => {
 app.delete('/api/agents/:name', (req, res) => {
     try {
         const { name } = req.params;
+        if (!isSafeAgentName(name)) {
+            return res.status(400).json({ error: ERROR_CODES.INVALID_AGENT_NAME, code: 'INVALID_AGENT_NAME' });
+        }
+
         const config = loadConfig() || {};
 
         if (config.agent && config.agent[name]) {
@@ -1617,6 +1639,10 @@ app.delete('/api/agents/:name', (req, res) => {
 app.post('/api/agents/:name/toggle', (req, res) => {
     try {
         const { name } = req.params;
+        if (!isSafeAgentName(name)) {
+            return res.status(400).json({ error: ERROR_CODES.INVALID_AGENT_NAME, code: 'INVALID_AGENT_NAME' });
+        }
+
         const studio = loadStudioConfig();
         const disabled = new Set(studio.disabledAgents || []);
         if (disabled.has(name)) disabled.delete(name); else disabled.add(name);
@@ -1757,6 +1783,7 @@ app.get('/api/backup', (req, res) => {
 app.post('/api/restore', (req, res) => {
     try {
         const { studioConfig, opencodeConfig, skills, plugins } = req.body;
+        assertSafeBackupResourceNames(req.body || {});
         
         if (studioConfig) saveStudioConfig(studioConfig);
         if (opencodeConfig) saveConfig(opencodeConfig);
@@ -1781,7 +1808,7 @@ app.post('/api/restore', (req, res) => {
         
         res.json({ success: true });
     } catch (err) {
-        res.status(500).json({ error: err.message });
+        sendErrorResponse(res, err);
     }
 });
 
@@ -1854,6 +1881,8 @@ function buildBackupData() {
 }
 
 function restoreFromBackup(backup, studio) {
+    assertSafeBackupResourceNames(backup || {});
+
     if (backup.studioConfig) {
         const merged = { 
             ...backup.studioConfig, 
@@ -2049,7 +2078,7 @@ app.post('/api/sync/pull', async (req, res) => {
         
         res.json({ success: true, timestamp: backup.timestamp, skills: (backup.skills || []).length, plugins: (backup.plugins || []).length });
     } catch (err) {
-        res.status(500).json({ error: err.message });
+        sendErrorResponse(res, err);
     }
 });
 
@@ -2098,7 +2127,7 @@ app.post('/api/sync/auto', async (req, res) => {
         
         res.json({ action: 'none', reason: 'local is current' });
     } catch (err) {
-        res.status(500).json({ error: err.message });
+        sendErrorResponse(res, err);
     }
 });
 
@@ -3181,7 +3210,7 @@ app.get('/api/skills', (req, res) => {
 
 app.get('/api/skills/:name', (req, res) => {
     const { name } = req.params;
-    if (!/^[a-zA-Z0-9_-s]+$/.test(name)) {
+    if (!isSafeSkillName(name)) {
         return res.status(400).json({ error: ERROR_CODES.INVALID_SKILL_NAME, code: 'INVALID_SKILL_NAME' });
     }
 
@@ -3202,7 +3231,7 @@ app.get('/api/skills/:name', (req, res) => {
 
 app.post('/api/skills/:name', (req, res) => {
     const { name } = req.params;
-    if (!/^[a-zA-Z0-9_-s]+$/.test(name)) {
+    if (!isSafeSkillName(name)) {
         return res.status(400).json({ error: ERROR_CODES.INVALID_SKILL_NAME, code: 'INVALID_SKILL_NAME' });
     }
 
@@ -3242,7 +3271,7 @@ app.post('/api/skills/:name', (req, res) => {
 
 app.delete('/api/skills/:name', (req, res) => {
     const { name } = req.params;
-    if (!/^[a-zA-Z0-9_-s]+$/.test(name)) {
+    if (!isSafeSkillName(name)) {
         return res.status(400).json({ error: ERROR_CODES.INVALID_SKILL_NAME, code: 'INVALID_SKILL_NAME' });
     }
 
@@ -3270,6 +3299,10 @@ app.delete('/api/skills/:name', (req, res) => {
 
 app.post('/api/skills/:name/toggle', (req, res) => {
     const { name } = req.params;
+    if (!isSafeSkillName(name)) {
+        return res.status(400).json({ error: ERROR_CODES.INVALID_SKILL_NAME, code: 'INVALID_SKILL_NAME' });
+    }
+
     const studio = loadStudioConfig();
     studio.disabledSkills = studio.disabledSkills || [];
     
@@ -3342,6 +3375,9 @@ app.get('/api/plugins', (req, res) => {
 
 app.get('/api/plugins/:name', (req, res) => {
     const { name } = req.params;
+    if (!isSafePluginName(name)) {
+        return res.status(400).json({ error: ERROR_CODES.INVALID_PLUGIN_NAME, code: 'INVALID_PLUGIN_NAME' });
+    }
 
     for (const dirInfo of getPluginDirs()) {
         const possiblePaths = [
@@ -3364,6 +3400,9 @@ app.get('/api/plugins/:name', (req, res) => {
 app.post('/api/plugins/:name', (req, res) => {
     const { name } = req.params;
     const { content } = req.body;
+    if (!isSafePluginName(name)) {
+        return res.status(400).json({ error: ERROR_CODES.INVALID_PLUGIN_NAME, code: 'INVALID_PLUGIN_NAME' });
+    }
 
     for (const dirInfo of getPluginDirs()) {
         const possiblePaths = [
@@ -3400,6 +3439,9 @@ app.post('/api/plugins/:name', (req, res) => {
 
 app.delete('/api/plugins/:name', (req, res) => {
     const { name } = req.params;
+    if (!isSafePluginName(name)) {
+        return res.status(400).json({ error: ERROR_CODES.INVALID_PLUGIN_NAME, code: 'INVALID_PLUGIN_NAME' });
+    }
 
     let deleted = false;
     for (const dirInfo of getPluginDirs()) {

--- a/server/lib/resource-names.js
+++ b/server/lib/resource-names.js
@@ -1,0 +1,77 @@
+const MAX_RESOURCE_NAME_LENGTH = 128;
+
+const SAFE_BASIC_NAME_RE = /^[A-Za-z0-9_-]+$/;
+const SAFE_SPACED_NAME_RE = /^[A-Za-z0-9 _-]+$/;
+const SAFE_DOTTED_NAME_RE = /^[A-Za-z0-9_. -]+$/;
+
+function hasUnsafePathSegment(name) {
+    return (
+        name === '.' ||
+        name === '..' ||
+        name.includes('/') ||
+        name.includes('\\') ||
+        name.includes('\0')
+    );
+}
+
+function isSafeResourceName(name, { allowSpaces = false, allowDots = false } = {}) {
+    if (typeof name !== 'string') return false;
+    if (!name || name.length > MAX_RESOURCE_NAME_LENGTH) return false;
+    if (name.trim() !== name) return false;
+    if (hasUnsafePathSegment(name)) return false;
+
+    const pattern = allowDots
+        ? SAFE_DOTTED_NAME_RE
+        : allowSpaces
+            ? SAFE_SPACED_NAME_RE
+            : SAFE_BASIC_NAME_RE;
+
+    return pattern.test(name);
+}
+
+function isSafeSkillName(name) {
+    return isSafeResourceName(name);
+}
+
+function isSafePluginName(name) {
+    return isSafeResourceName(name, { allowSpaces: true, allowDots: true });
+}
+
+function isSafeAgentName(name) {
+    return isSafeResourceName(name, { allowSpaces: true });
+}
+
+function findInvalidNamedEntry(entries, isSafeName) {
+    if (!Array.isArray(entries)) return null;
+    return entries.find((entry) => !entry || !isSafeName(entry.name)) || null;
+}
+
+function createInvalidResourceNameError(type, name) {
+    const error = new Error(`Invalid ${type} name: ${typeof name === 'string' ? name : String(name)}`);
+    error.statusCode = 400;
+    error.code = `INVALID_${type.toUpperCase()}_NAME`;
+    return error;
+}
+
+function assertSafeBackupResourceNames(backup = {}) {
+    const invalidSkill = findInvalidNamedEntry(backup.skills, isSafeSkillName);
+    if (invalidSkill) {
+        throw createInvalidResourceNameError('skill', invalidSkill.name);
+    }
+
+    const invalidPlugin = findInvalidNamedEntry(backup.plugins, isSafePluginName);
+    if (invalidPlugin) {
+        throw createInvalidResourceNameError('plugin', invalidPlugin.name);
+    }
+}
+
+module.exports = {
+    MAX_RESOURCE_NAME_LENGTH,
+    isSafeResourceName,
+    isSafeSkillName,
+    isSafePluginName,
+    isSafeAgentName,
+    findInvalidNamedEntry,
+    createInvalidResourceNameError,
+    assertSafeBackupResourceNames,
+};

--- a/server/lib/resource-names.js
+++ b/server/lib/resource-names.js
@@ -3,6 +3,7 @@ const MAX_RESOURCE_NAME_LENGTH = 128;
 const SAFE_BASIC_NAME_RE = /^[A-Za-z0-9_-]+$/;
 const SAFE_SPACED_NAME_RE = /^[A-Za-z0-9 _-]+$/;
 const SAFE_DOTTED_NAME_RE = /^[A-Za-z0-9_. -]+$/;
+const SAFE_AUTH_PROFILE_NAME_RE = /^[A-Za-z0-9_.@+ -]+$/;
 
 function hasUnsafePathSegment(name) {
     return (
@@ -41,6 +42,14 @@ function isSafeAgentName(name) {
     return isSafeResourceName(name, { allowSpaces: true });
 }
 
+function isSafeAuthProfileName(name) {
+    if (typeof name !== 'string') return false;
+    if (!name || name.length > MAX_RESOURCE_NAME_LENGTH) return false;
+    if (name.trim() !== name) return false;
+    if (hasUnsafePathSegment(name)) return false;
+    return SAFE_AUTH_PROFILE_NAME_RE.test(name);
+}
+
 function findInvalidNamedEntry(entries, isSafeName) {
     if (!Array.isArray(entries)) return null;
     return entries.find((entry) => !entry || !isSafeName(entry.name)) || null;
@@ -53,13 +62,28 @@ function createInvalidResourceNameError(type, name) {
     return error;
 }
 
+function createInvalidResourceListError(type) {
+    const error = new Error(`Invalid ${type} list`);
+    error.statusCode = 400;
+    error.code = `INVALID_${type.toUpperCase()}_LIST`;
+    return error;
+}
+
+function getNamedEntries(entries, type) {
+    if (entries === undefined) return [];
+    if (!Array.isArray(entries)) throw createInvalidResourceListError(type);
+    return entries;
+}
+
 function assertSafeBackupResourceNames(backup = {}) {
-    const invalidSkill = findInvalidNamedEntry(backup.skills, isSafeSkillName);
+    const skills = getNamedEntries(backup.skills, 'skills');
+    const invalidSkill = findInvalidNamedEntry(skills, isSafeSkillName);
     if (invalidSkill) {
         throw createInvalidResourceNameError('skill', invalidSkill.name);
     }
 
-    const invalidPlugin = findInvalidNamedEntry(backup.plugins, isSafePluginName);
+    const plugins = getNamedEntries(backup.plugins, 'plugins');
+    const invalidPlugin = findInvalidNamedEntry(plugins, isSafePluginName);
     if (invalidPlugin) {
         throw createInvalidResourceNameError('plugin', invalidPlugin.name);
     }
@@ -71,6 +95,7 @@ module.exports = {
     isSafeSkillName,
     isSafePluginName,
     isSafeAgentName,
+    isSafeAuthProfileName,
     findInvalidNamedEntry,
     createInvalidResourceNameError,
     assertSafeBackupResourceNames,

--- a/server/lib/resource-names.test.js
+++ b/server/lib/resource-names.test.js
@@ -1,0 +1,44 @@
+const assert = require('node:assert/strict');
+const { describe, it } = require('node:test');
+
+const {
+    assertSafeBackupResourceNames,
+    isSafeAgentName,
+    isSafePluginName,
+    isSafeSkillName,
+} = require('./resource-names');
+
+describe('resource name policy', () => {
+    it('accepts normal skill, plugin, and agent names', () => {
+        assert.equal(isSafeSkillName('code-review'), true);
+        assert.equal(isSafePluginName('watcher.plugin'), true);
+        assert.equal(isSafePluginName('watcher.ts'), true);
+        assert.equal(isSafeAgentName('Build Agent'), true);
+    });
+
+    it('rejects path traversal and path separator names', () => {
+        for (const name of ['../escape', '..\\escape', '/tmp/escape', 'nested/plugin', '.', '..']) {
+            assert.equal(isSafeSkillName(name), false, `skill ${name}`);
+            assert.equal(isSafePluginName(name), false, `plugin ${name}`);
+            assert.equal(isSafeAgentName(name), false, `agent ${name}`);
+        }
+    });
+
+    it('rejects malformed backup skill and plugin names before restore writes', () => {
+        assert.doesNotThrow(() => {
+            assertSafeBackupResourceNames({
+                skills: [{ name: 'debugging', content: 'ok' }],
+                plugins: [{ name: 'hooks', content: 'ok' }],
+            });
+        });
+
+        assert.throws(
+            () => assertSafeBackupResourceNames({ skills: [{ name: '../escape', content: 'bad' }] }),
+            /Invalid skill name/
+        );
+        assert.throws(
+            () => assertSafeBackupResourceNames({ plugins: [{ name: '../escape', content: 'bad' }] }),
+            /Invalid plugin name/
+        );
+    });
+});

--- a/server/lib/resource-names.test.js
+++ b/server/lib/resource-names.test.js
@@ -4,6 +4,7 @@ const { describe, it } = require('node:test');
 const {
     assertSafeBackupResourceNames,
     isSafeAgentName,
+    isSafeAuthProfileName,
     isSafePluginName,
     isSafeSkillName,
 } = require('./resource-names');
@@ -14,6 +15,7 @@ describe('resource name policy', () => {
         assert.equal(isSafePluginName('watcher.plugin'), true);
         assert.equal(isSafePluginName('watcher.ts'), true);
         assert.equal(isSafeAgentName('Build Agent'), true);
+        assert.equal(isSafeAuthProfileName('jikui.feng+oss@example.com'), true);
     });
 
     it('rejects path traversal and path separator names', () => {
@@ -21,6 +23,13 @@ describe('resource name policy', () => {
             assert.equal(isSafeSkillName(name), false, `skill ${name}`);
             assert.equal(isSafePluginName(name), false, `plugin ${name}`);
             assert.equal(isSafeAgentName(name), false, `agent ${name}`);
+            assert.equal(isSafeAuthProfileName(name), false, `auth profile ${name}`);
+        }
+    });
+
+    it('rejects malformed auth profile names', () => {
+        for (const name of [' user@example.com', 'user@example.com ', 'profile:name', 'profile*name', '']) {
+            assert.equal(isSafeAuthProfileName(name), false, `auth profile ${name}`);
         }
     });
 
@@ -39,6 +48,14 @@ describe('resource name policy', () => {
         assert.throws(
             () => assertSafeBackupResourceNames({ plugins: [{ name: '../escape', content: 'bad' }] }),
             /Invalid plugin name/
+        );
+        assert.throws(
+            () => assertSafeBackupResourceNames({ skills: { name: 'debugging', content: 'bad' } }),
+            /Invalid skills list/
+        );
+        assert.throws(
+            () => assertSafeBackupResourceNames({ plugins: { name: 'hooks', content: 'bad' } }),
+            /Invalid plugins list/
         );
     });
 });


### PR DESCRIPTION
## Summary
- add a shared server-side resource name policy for config-backed resources
- reject unsafe skill, plugin, and agent names before file reads/writes/deletes
- validate backup/sync restore skill and plugin entries before applying any writes

## Why
Several local config resource paths are built from request or backup payload names, for example plugin file writes and backup restore entries. A name like `../escape` can escape the intended `skills/` or `plugin/` directory when joined into a filesystem path. This keeps those names as simple local resource names before they reach path construction.

## Validation run
- `node --test server/lib/cors-policy.test.js server/lib/resource-names.test.js`
- `node --check server/index.js && node --check server/lib/resource-names.js && node --check server/lib/resource-names.test.js`
- `git diff --check`

## AI assistance disclosure
- agent_name: OpenAI Codex
- agent_version: codex-cli 0.134.0
- model_used: GPT-5
- human_testing: Completed local validation with `node --test server/lib/cors-policy.test.js server/lib/resource-names.test.js`, `node --check server/index.js`, `node --check server/lib/resource-names.js`, `node --check server/lib/resource-names.test.js`, and `git diff --check`.
- contribution_summary: Added server-side validation for config resource names before local file operations.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds server-side validation for config-backed resource names. The main changes are:

- Shared name policy helpers for skills, plugins, agents, and auth profiles.
- Restore and sync validation before skill or plugin writes.
- Route-level checks before file reads, writes, deletes, and profile updates.
- Tests for traversal rejection and malformed restore lists.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- Malformed restore lists now fail before restore writes.
- The added validators are wired into the changed file-operation paths.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/lib/resource-names.js | Adds shared resource-name validators and rejects malformed restore lists. |
| server/index.js | Applies resource-name validation before restore, route, and auth profile file operations. |
| server/lib/resource-names.test.js | Adds tests for valid names, traversal rejection, auth profile names, and malformed restore payloads. |

<sub>Reviews (2): Last reviewed commit: ["fix(server): validate auth profile names"](https://github.com/microck/opencode-studio/commit/f5d74f6aadcf36f981dda1ada9e21e1a0a0f0ccf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42329892)</sub>

<!-- /greptile_comment -->