### PR TITLE
Fix path traversal in profile operations

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -5564,8 +5564,8 @@ async function startServer() {
     ['google', 'anthropic', 'openai', 'xai', 'openrouter', 'together', 'mistral', 'deepseek', 'amazon-bedrock', 'azure', 'github-copilot'].forEach(p => importCurrentAuthToPool(p));
 
     const port = await findAvailablePort(DEFAULT_PORT);
-    app.listen(port, () => {
-        console.log(`Server running at http://localhost:${port}`);
+    app.listen(port, '127.0.0.1', () => {
+        console.log(`Server running at http://127.0.0.1:${port}`);
         // Initial sync on startup if enabled
         setTimeout(() => {
             const studio = loadStudioConfig();

--- a/server/profile-manager.js
+++ b/server/profile-manager.js
@@ -7,7 +7,11 @@ const OPENCODE_DIR = path.join(HOME_DIR, '.config', 'opencode');
 const PROFILES_DIR = path.join(HOME_DIR, '.config', 'opencode-profiles');
 
 function safeName(name) {
-    if (!name || name.includes('/') || name.includes('\\') || name.includes('..')) {
+    if (!name || typeof name !== 'string' || name.includes('/') || name.includes('\\')) {
+        throw new Error('Invalid profile name');
+    }
+    const target = path.resolve(PROFILES_DIR, name);
+    if (path.dirname(target) !== path.resolve(PROFILES_DIR)) {
         throw new Error('Invalid profile name');
     }
     return name;

--- a/server/profile-manager.js
+++ b/server/profile-manager.js
@@ -96,6 +96,7 @@ function activateProfile(name) {
 }
 
 module.exports = {
+    safeName,
     listProfiles,
     createProfile,
     deleteProfile,

--- a/server/profile-manager.js
+++ b/server/profile-manager.js
@@ -6,6 +6,13 @@ const HOME_DIR = os.homedir();
 const OPENCODE_DIR = path.join(HOME_DIR, '.config', 'opencode');
 const PROFILES_DIR = path.join(HOME_DIR, '.config', 'opencode-profiles');
 
+function safeName(name) {
+    if (!name || name.includes('/') || name.includes('\\') || name.includes('..')) {
+        throw new Error('Invalid profile name');
+    }
+    return name;
+}
+
 if (!fs.existsSync(PROFILES_DIR)) {
     fs.mkdirSync(PROFILES_DIR, { recursive: true });
 }
@@ -51,6 +58,7 @@ function listProfiles() {
 }
 
 function createProfile(name) {
+    safeName(name);
     const dir = path.join(PROFILES_DIR, name);
     if (fs.existsSync(dir)) throw new Error('Profile already exists');
     fs.mkdirSync(dir, { recursive: true });
@@ -58,6 +66,7 @@ function createProfile(name) {
 }
 
 function deleteProfile(name) {
+    safeName(name);
     const { active } = listProfiles();
     if (name === active) throw new Error('Cannot delete active profile');
     if (name === 'default') throw new Error('Cannot delete default profile');
@@ -70,6 +79,7 @@ function deleteProfile(name) {
 }
 
 function activateProfile(name) {
+    safeName(name);
     const target = path.join(PROFILES_DIR, name);
     if (!fs.existsSync(target)) throw new Error('Profile not found');
     

--- a/server/profile-manager.test.js
+++ b/server/profile-manager.test.js
@@ -1,0 +1,15 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { safeName } = require('./profile-manager');
+
+test('safeName rejects traversal and dot names', () => {
+    for (const bad of ['.', '..', '../evil', 'a/b', '..\\..', '/etc/passwd', '', null]) {
+        assert.throws(() => safeName(bad), /Invalid profile name/, `should reject ${JSON.stringify(bad)}`);
+    }
+});
+
+test('safeName accepts direct-child names', () => {
+    for (const ok of ['work', 'personal', 'my.profile', 'p_1-2']) {
+        assert.strictEqual(safeName(ok), ok);
+    }
+});


### PR DESCRIPTION
Reject profile names containing path separators or traversal sequences to prevent arbitrary filesystem delete/create/symlink.

Fixes #54

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens profile filesystem operations against unsafe profile names. The main changes are:

- Adds `safeName` validation before profile create, delete, and activate operations.
- Rejects empty names, non-string names, path separators, traversal names, and dot-only names.
- Adds tests for rejected traversal inputs and accepted direct-child profile names.
- Binds the server listener explicitly to `127.0.0.1`.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

Profile operations now validate names before path construction, and the previously reported dot-name case is covered by validation and tests.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Unit tests were run and all tests passed (2/2) in the T-Rex suite.
- The manager harness was executed to validate profile name handling and safe profile operations, confirming that invalid names throw an error and that create/activate and delete behaviors succeed.
- The API harness was executed to verify API responses for invalid and valid profile names, confirming 400 for invalid requests and 200 for safe operations.
- A parent-revision comparison artifact was captured to verify that the baseline HEAD^ contained the same validation behavior as the current change.

<a href="https://app.greptile.com/trex/runs/15471311/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/profile-manager.js | Adds `safeName` validation before profile create/delete/activate operations to reject traversal, separators, empty values, and non-direct child paths. |
| server/profile-manager.test.js | Adds focused tests covering rejected traversal/dot profile names and accepted direct-child profile names. |
| server/index.js | Binds the local server listener explicitly to `127.0.0.1` and updates the startup URL accordingly. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
participant Client
participant API as Profile API
participant PM as profile-manager
participant FS as Filesystem

Client->>API: create/delete/activate profile(name)
API->>PM: profile operation(name)
PM->>PM: safeName(name)
alt invalid name
    PM-->>API: throw Invalid profile name
    API-->>Client: 400 error
else valid direct-child name
    PM->>FS: create/remove/symlink under PROFILES_DIR
    FS-->>PM: success
    PM-->>API: "{ success: true }"
    API-->>Client: success response
end
```

<sub>Reviews (2): Last reviewed commit: ["Add regression test for safeName path co..."](https://github.com/microck/opencode-studio/commit/9ae0139636b87fabfce60143ee65e9992c7ccce9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45399213)</sub>

<!-- /greptile_comment -->